### PR TITLE
Metadata

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo build --no-default-features
+      - run: cargo test --no-default-features
       - run: cargo build --examples --all-features
       - run: cargo test --all-features
 
@@ -30,4 +30,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo run --example read_zstd_archive -- ./tests/sample-bag.tar.zst
-      - run: cargo run --example blake3_generate --features="generate" -- ${{ runner.temp }}/test_bag
+      - run: cargo run --example blake3_generate -- ${{ runner.temp }}/test_bag

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo build --no-default-features
       - run: cargo build --examples --all-features
       - run: cargo test --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "digest",
  "futures",
  "hex",
+ "jiff",
  "md-5",
  "sha2",
  "thiserror",
@@ -322,6 +323,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "jiff"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52113e019082508e868f92202f6e55c690c69990b17c350db01813cdf1dc1b19"
 
 [[package]]
 name = "jobserver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ description = "Create and load BagIt containers"
 repository = "https://github.com/deadbaed/async-bagit-rs"
 
 [features]
-default = ["generate"]
+default = ["generate", "date"]
 generate = ["dep:futures"]
+date = ["dep:jiff"]
 
 [dependencies]
 thiserror = "1"
@@ -17,6 +18,7 @@ tokio = { version = "1", features = ["fs", "rt", "io-util"] }
 digest = "0.10"
 hex = "0.4"
 futures = { version = "0.3", optional = true }
+jiff = { version = "0.1", optional = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ description = "Create and load BagIt containers"
 repository = "https://github.com/deadbaed/async-bagit-rs"
 
 [features]
-default = ["generate", "date"]
-generate = ["dep:futures"]
+default = ["date"]
 date = ["dep:jiff"]
 
 [dependencies]
@@ -17,7 +16,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["fs", "rt", "io-util"] }
 digest = "0.10"
 hex = "0.4"
-futures = { version = "0.3", optional = true }
+futures = "0.3"
 jiff = { version = "0.1", optional = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
@@ -31,7 +30,6 @@ async-compression = { version = "0.4", features = ["tokio", "zstdmt"] }
 
 [[example]]
 name = "blake3_generate"
-required-features = ["generate"]
 
 [[example]]
 name = "read_zstd_archive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ repository = "https://github.com/deadbaed/async-bagit-rs"
 
 [features]
 default = ["generate"]
-generate = []
+generate = ["dep:futures"]
 
 [dependencies]
 thiserror = "1"
 tokio = { version = "1", features = ["fs", "rt", "io-util"] }
 digest = "0.10"
 hex = "0.4"
-futures = "0.3"
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/changelog.md
+++ b/changelog.md
@@ -9,11 +9,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com).
 ### Added
 
 - Support for tag manifests
+- Added `Metadata` struct, read/write tags from/to file bag-data.txt
+- Storing metadata tags inside `BagIt` struct
+- Store file size in `Payload` struct
+
+Supporting reading and writing commonly used tags through `Metadata` struct:
+- `BagIt-Version`
+- `Tag-File-Character-Encoding`
+- `Bagging-Date` (with [`jiff`](http://docs.rs/jiff) crate)
+- `Payload-Oxum`
+- Custom tags with key/value stored as strings
 
 ### Changed
 
 - Write a tag manifest when creating a bag
 - Validate tag manifest if present when reading a bag
+- Using new `Metadata` struct for reading and writing bagit.txt file
 
 ### Fixed
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,6 @@ When creating bags, the crate **will copy files** when adding them to the bag. M
 ## TODO
 
 - [ ] `bag-info.txt` with common labels
-- [ ] `bagit.txt`: Don't hardcode it lol
 - [ ] `fetch.txt`: I do not have any use for this yet, and seems a bunch of work to implement it
 - [ ] Support multiple checksum algorithms at the same time
 - [ ] Respect the spec regarding filename casing

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,6 @@ When creating bags, the crate **will copy files** when adding them to the bag. M
 
 ## TODO
 
-- [ ] `bag-info.txt` with common labels
 - [ ] `fetch.txt`: I do not have any use for this yet, and seems a bunch of work to implement it
 - [ ] Support multiple checksum algorithms at the same time
 - [ ] Respect the spec regarding filename casing

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,11 @@ Rust library to create and read [BagIt](https://en.wikipedia.org/wiki/BagIt) con
 ## Requirements to use in your crate
 
 - Tokio runtime
-- Nightly Rust, until [feature `iter_next_chunk`](https://github.com/rust-lang/rust/issues/98326) is stabilized, sorry. Feel free to propose a patch to have something working on stable in the mean time!
+- Nightly Rust until features shown in table below are stabilized, sorry. Feel free to propose a patch to have something working on stable in the meantime!
+
+| Nightly feature | Tracking issue |
+| --- | --- |
+| `iter_next_chunk` | [#98326](https://github.com/rust-lang/rust/issues/98326) |
 
 ## Notes when using the crate
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,5 +1,6 @@
 use crate::{
     checksum::{compute_checksum_file, ChecksumComputeError},
+    metadata::Metadata,
     ChecksumAlgorithm, Payload,
 };
 use digest::Digest;
@@ -119,7 +120,13 @@ impl<'algo> super::BagIt<'_, 'algo> {
 
     async fn write_bagit_file(&self) -> Result<(), std::io::Error> {
         let manifest_path = self.path.join("bagit.txt");
-        let contents = "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8\n";
+
+        let contents = [
+            Metadata::BagitVersion { major: 1, minor: 0 },
+            Metadata::Encoding,
+        ]
+        .map(|tag| tag.to_string())
+        .join("\n");
 
         fs::write(manifest_path, contents).await
     }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -91,13 +91,18 @@ impl<'algo> super::BagIt<'_, 'algo> {
         Ok(())
     }
 
+    #[cfg(feature = "date")]
+    pub fn add_bagging_date(&mut self, date: jiff::civil::Date) {
+        self.tags.push(Metadata::BaggingDate(date));
+    }
+
     /// Procedure to make a bagit container ready for distribution
     ///
     /// - Write manifest file with payloads and their checksums
     /// - Bagit file declaration
     /// - Information file about bag
     /// - Manifest with checksums of files that are not data payload
-    pub async fn finalize<ChecksumAlgo: Digest>(&self) -> Result<(), GenerateError> {
+    pub async fn finalize<ChecksumAlgo: Digest>(&mut self) -> Result<(), GenerateError> {
         self.write_manifest_file(self.manifest_name(), self.payload_items())
             .await
             .map_err(|e| GenerateError::Finalize(e.kind()))?;
@@ -108,6 +113,16 @@ impl<'algo> super::BagIt<'_, 'algo> {
         bagit_file.add(Metadata::Encoding);
         bagit_file
             .write(self.path.join("bagit.txt"))
+            .await
+            .map_err(|e| GenerateError::Finalize(e.kind()))?;
+
+        // Write `bag-info.txt`
+        self.tags.push(Metadata::PayloadOctetStreamSummary {
+            stream_count: self.payload_items().count(),
+            octet_count: self.payload_items().map(|payload| payload.bytes()).sum(),
+        });
+        MetadataFile::from(self.tags.clone())
+            .write(self.path.join("bag-info.txt"))
             .await
             .map_err(|e| GenerateError::Finalize(e.kind()))?;
 
@@ -133,7 +148,11 @@ impl<'algo> super::BagIt<'_, 'algo> {
 
     async fn write_tagmanifest_file<ChecksumAlgo: Digest>(&self) -> Result<(), GenerateError> {
         // Files for tag manifest
-        let items = ["bagit.txt".into(), self.manifest_name()];
+        let items = [
+            "bagit.txt".into(),
+            "bag-info.txt".into(),
+            self.manifest_name(),
+        ];
 
         // Compute their checksums
         let checksums_items = futures::future::join_all(
@@ -161,10 +180,12 @@ impl<'algo> super::BagIt<'_, 'algo> {
 #[cfg(test)]
 mod test {
     use crate::{Algorithm, BagIt, ChecksumAlgorithm};
+    #[cfg(feature = "date")]
+    use jiff::civil::Date;
     use sha2::Sha256;
 
     #[tokio::test]
-    async fn basic_bag_sha256() {
+    async fn bag_sha256() {
         let temp_directory = async_tempfile::TempDir::new().await.unwrap();
         let temp_directory = temp_directory.to_path_buf();
 
@@ -199,6 +220,10 @@ mod test {
         let bagit_file = temp_directory.join("bagit.txt");
         assert!(!bagit_file.is_file());
 
+        // Bag info file
+        let bag_info_file = temp_directory.join("bag-info.txt");
+        assert!(!bag_info_file.is_file());
+
         // Tag manifest file
         let tag_manifest_name = format!("tagmanifest-{}.txt", algo.algorithm());
         let tag_manifest_file = temp_directory.join(tag_manifest_name);
@@ -210,6 +235,52 @@ mod test {
         // Make sure files have been created
         assert!(manifest_file.is_file());
         assert!(bagit_file.is_file());
+        assert!(bag_info_file.is_file());
         assert!(tag_manifest_file.is_file());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "date")]
+    async fn bag_with_date() {
+        use crate::metadata::Metadata;
+
+        let temp_directory = async_tempfile::TempDir::new().await.unwrap();
+        let temp_directory = temp_directory.to_path_buf();
+
+        let algo = ChecksumAlgorithm::<Sha256>::new(Algorithm::Sha256);
+
+        let mut bag = BagIt::new_empty(&temp_directory, &algo);
+
+        let mut source_directory = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        source_directory.push("tests/sample-bag/data");
+
+        // Add files to the bag
+        let temp_payload_destination = temp_directory.join("data");
+        for file in ["paper_bag.jpg"] {
+            bag.add_file::<Sha256>(source_directory.join(file))
+                .await
+                .unwrap();
+            assert!(temp_payload_destination.join(file).is_file());
+        }
+
+        bag.add_bagging_date(Date::new(2024, 8, 1).unwrap());
+
+        // Finalize bag
+        assert_eq!(bag.finalize::<Sha256>().await, Ok(()));
+
+        // Read bag, make sure date is present
+        let read_bag = BagIt::read_existing::<Sha256>(temp_directory, &algo)
+            .await
+            .unwrap();
+        assert_eq!(
+            read_bag.tags,
+            vec![
+                Metadata::BaggingDate(Date::new(2024, 8, 1).unwrap()),
+                Metadata::PayloadOctetStreamSummary {
+                    octet_count: 19895,
+                    stream_count: 1
+                }
+            ]
+        );
     }
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -49,6 +49,7 @@ impl<'algo> super::BagIt<'_, 'algo> {
             path: directory.as_ref().to_path_buf(),
             checksum_algorithm: checksum_algorithm.algorithm(),
             items: vec![],
+            tags: vec![],
         }
     }
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -84,7 +84,8 @@ impl<'algo> super::BagIt<'_, 'algo> {
         let relative_path = destination.strip_prefix(self.path())?.to_path_buf();
 
         // Add to list of items in bag
-        self.items.push(Payload::new(self.path(), relative_path, file_checksum)?);
+        self.items
+            .push(Payload::new(self.path(), relative_path, file_checksum)?);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,9 @@ mod checksum;
 #[cfg(feature = "generate")]
 mod generate;
 mod manifest;
+mod metadata;
 mod payload;
 mod read;
-mod metadata;
 
 /// Possible errors when manipulating BagIt containers
 pub mod error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod error {
 
 pub use algorithm::{Algorithm, ChecksumAlgorithm};
 pub use checksum::Checksum;
+use metadata::Metadata;
 pub use payload::Payload;
 
 #[derive(Debug, PartialEq)]
@@ -119,6 +120,9 @@ pub struct BagIt<'a, 'algo> {
 
     /// Which algorithm to use for checksums of the items
     checksum_algorithm: &'algo Algorithm,
+
+    /// Metadata tags
+    tags: Vec<Metadata>,
 }
 
 impl<'a, 'algo> BagIt<'a, 'algo> {
@@ -127,11 +131,13 @@ impl<'a, 'algo> BagIt<'a, 'algo> {
         directory: impl AsRef<std::path::Path>,
         items: Vec<Payload<'a>>,
         checksum_algorithm: &'algo Algorithm,
+        tags: Vec<Metadata>,
     ) -> Result<Self, error::ReadError> {
         Ok(Self {
             path: directory.as_ref().to_path_buf(),
             items,
             checksum_algorithm,
+            tags,
         })
     }
 
@@ -266,6 +272,7 @@ mod test {
                     ),
                 ],
                 algo.algorithm(),
+                vec![],
             )
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@ bag.finalize::<AlgorithmToUse>().await.unwrap();
 
 mod algorithm;
 mod checksum;
-#[cfg(feature = "generate")]
 mod generate;
 mod manifest;
 mod metadata;
@@ -95,7 +94,6 @@ mod read;
 /// Possible errors when manipulating BagIt containers
 pub mod error {
     pub use crate::checksum::ChecksumComputeError;
-    #[cfg(feature = "generate")]
     pub use crate::generate::GenerateError;
     pub use crate::payload::PayloadError;
     pub use crate::read::ReadError;
@@ -205,7 +203,6 @@ mod test {
     use std::path::Path;
 
     #[tokio::test]
-    #[cfg(feature = "generate")]
     async fn generate_and_read_basic_bag_sha256() {
         let temp_directory = async_tempfile::TempDir::new().await.unwrap();
         let temp_directory = temp_directory.to_path_buf();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ mod generate;
 mod manifest;
 mod payload;
 mod read;
+mod metadata;
 
 /// Possible errors when manipulating BagIt containers
 pub mod error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl<'a, 'algo> BagIt<'a, 'algo> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Algorithm, BagIt, ChecksumAlgorithm, Payload};
+    use crate::{metadata::Metadata, Algorithm, BagIt, ChecksumAlgorithm, Payload};
     use sha2::Sha256;
 
     #[tokio::test]
@@ -272,7 +272,10 @@ mod test {
                     ),
                 ],
                 algo.algorithm(),
-                vec![],
+                vec![Metadata::PayloadOctetStreamSummary {
+                    octet_count: 85766,
+                    stream_count: 5,
+                }],
             )
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,9 +198,8 @@ impl<'a, 'algo> BagIt<'a, 'algo> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Algorithm, BagIt, Checksum, ChecksumAlgorithm, Payload};
+    use crate::{Algorithm, BagIt, ChecksumAlgorithm, Payload};
     use sha2::Sha256;
-    use std::path::Path;
 
     #[tokio::test]
     async fn generate_and_read_basic_bag_sha256() {
@@ -240,35 +239,30 @@ mod test {
             let expected = BagIt::from_existing_items(
                 temp_directory,
                 vec![
-                    Payload::new(
-                        Path::new("data/bagit.md"),
-                        Checksum::from(
-                            "eccdbbade12ba878af8f2140cb00c914f427405a987de2670e5c3014faf59f8e",
-                        ),
+                    Payload::test_payload(
+                        "data/bagit.md",
+                        "eccdbbade12ba878af8f2140cb00c914f427405a987de2670e5c3014faf59f8e",
+                        6302,
                     ),
-                    Payload::new(
-                        Path::new("data/paper_bag.jpg"),
-                        Checksum::from(
-                            "2b22a8fd0dc46cbdc7a67b6cf588a03a8dd6f8ea23ce0b02e921ca5d79930bb2",
-                        ),
+                    Payload::test_payload(
+                        "data/paper_bag.jpg",
+                        "2b22a8fd0dc46cbdc7a67b6cf588a03a8dd6f8ea23ce0b02e921ca5d79930bb2",
+                        19895,
                     ),
-                    Payload::new(
-                        Path::new("data/rfc8493.txt"),
-                        Checksum::from(
-                            "4964147d2e6e16442d4a6dbfbe68178a8f33c3e791c06d68a8b33f51ad821537",
-                        ),
+                    Payload::test_payload(
+                        "data/rfc8493.txt",
+                        "4964147d2e6e16442d4a6dbfbe68178a8f33c3e791c06d68a8b33f51ad821537",
+                        48783,
                     ),
-                    Payload::new(
-                        Path::new("data/sources.csv"),
-                        Checksum::from(
-                            "0fe3bd6e7c36aa2c979f3330037b220c5ca88ed0eabf16622202dc0b33c44e72",
-                        ),
+                    Payload::test_payload(
+                        "data/sources.csv",
+                        "0fe3bd6e7c36aa2c979f3330037b220c5ca88ed0eabf16622202dc0b33c44e72",
+                        369,
                     ),
-                    Payload::new(
-                        Path::new("data/totebag.jpg"),
-                        Checksum::from(
-                            "38ff57167d746859f6383e80eb84ec0dd84de2ab1ed126ad317e73fbf502fb31",
-                        ),
+                    Payload::test_payload(
+                        "data/totebag.jpg",
+                        "38ff57167d746859f6383e80eb84ec0dd84de2ab1ed126ad317e73fbf502fb31",
+                        10417,
                     ),
                 ],
                 algo.algorithm(),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -77,7 +77,7 @@ impl Manifest {
     ) -> Result<Vec<Payload<'static>>, ReadError> {
         let checksum_file = fs::File::open(self)
             .await
-            .map_err(|e| ReadError::OpenChecksumFile(e.kind()))?;
+            .map_err(|e| ReadError::OpenFile(e.kind()))?;
         let mut checksum_file = BufReader::new(checksum_file);
 
         let mut items = Vec::new();
@@ -87,7 +87,7 @@ impl Manifest {
             let read_bytes = checksum_file
                 .read_line(&mut checksum_line)
                 .await
-                .map_err(|e| ReadError::ReadChecksumLine(e.kind()))?;
+                .map_err(|e| ReadError::ReadLine(e.kind()))?;
 
             // EOF
             if read_bytes == 0 {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,3 +1,5 @@
+mod file;
+
 #[cfg(feature = "date")]
 use jiff::civil::Date;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, fmt::Display, str::FromStr};
 
 pub const KEY_VERSION: &str = "BagIt-Version";
 pub const KEY_ENCODING: &str = "Tag-File-Character-Encoding";
+#[cfg(feature = "date")]
 pub const KEY_DATE: &str = "Bagging-Date";
 pub const KEY_OXUM: &str = "Payload-Oxum";
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -3,10 +3,10 @@ use jiff::civil::Date;
 
 use std::{borrow::Cow, fmt::Display, str::FromStr};
 
-const KEY_VERSION: &str = "BagIt-Version";
-const KEY_ENCODING: &str = "Tag-File-Character-Encoding";
-const KEY_DATE: &str = "Bagging-Date";
-const KEY_OXUM: &str = "Payload-Oxum";
+pub const KEY_VERSION: &str = "BagIt-Version";
+pub const KEY_ENCODING: &str = "Tag-File-Character-Encoding";
+pub const KEY_DATE: &str = "Bagging-Date";
+pub const KEY_OXUM: &str = "Payload-Oxum";
 
 #[derive(Debug, PartialEq)]
 pub enum Metadata<'a> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,316 @@
+#[cfg(feature = "date")]
+use jiff::civil::Date;
+
+use std::{borrow::Cow, fmt::Display, str::FromStr};
+
+const KEY_VERSION: &str = "BagIt-Version";
+const KEY_ENCODING: &str = "Tag-File-Character-Encoding";
+const KEY_DATE: &str = "Bagging-Date";
+const KEY_OXUM: &str = "Payload-Oxum";
+
+#[derive(Debug, PartialEq)]
+enum Metadata<'a> {
+    Custom {
+        key: Cow<'a, str>,
+        value: Cow<'a, str>,
+    },
+    BagitVersion {
+        major: u8,
+        minor: u8,
+    },
+    Encoding,
+    #[cfg(feature = "date")]
+    BaggingDate(Date),
+    PayloadOctetStreamSummary {
+        /// Count of bytes in all streams
+        octet_count: usize,
+        /// Number of streams (aka files)
+        stream_count: usize,
+    },
+}
+
+impl Metadata<'_> {
+    pub fn key(&self) -> &str {
+        match self {
+            Metadata::Custom { key, .. } => key,
+            Metadata::BagitVersion { .. } => KEY_VERSION,
+            Metadata::Encoding => KEY_ENCODING,
+            #[cfg(feature = "date")]
+            Metadata::BaggingDate(_) => KEY_DATE,
+            Metadata::PayloadOctetStreamSummary { .. } => KEY_OXUM,
+        }
+    }
+
+    pub fn value(&self) -> String {
+        match self {
+            Metadata::Custom { value, .. } => value.to_string(),
+            Metadata::BagitVersion { major, minor } => format!("{major}.{minor}"),
+            Metadata::Encoding => "UTF-8".to_string(),
+            #[cfg(feature = "date")]
+            Metadata::BaggingDate(date) => date.to_string(),
+            Metadata::PayloadOctetStreamSummary {
+                octet_count,
+                stream_count,
+            } => format!("{octet_count}.{stream_count}"),
+        }
+    }
+}
+
+impl Display for Metadata<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.key(), self.value())
+    }
+}
+
+#[derive(thiserror::Error, Debug, PartialEq)]
+enum MetadataError {
+    /// Metadata format must be: "<key>: <value>"
+    #[error("Invalid format")]
+    Format,
+    /// Some characters are forbidden for labels
+    #[error("Metadata key contains forbidden character `:`")]
+    KeyForbiddenCharacter,
+    /// Some characters are forbidden for values
+    #[error("Metadata value contains forbidden character `<whitespace>`")]
+    ValueForbiddenCharacter,
+    /// Some characters are forbidden for values
+    #[error("Failed to parse metadata value for key `{0}`")]
+    ValueParsing(&'static str),
+    /// Got other encoding value, accepting only utf-8
+    #[error("Only UTF-8 is supported")]
+    Encoding,
+}
+
+impl FromStr for Metadata<'_> {
+    type Err = MetadataError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (key, value) = s.split_once(": ").ok_or(MetadataError::Format)?;
+
+        Self::validate_format(key, value)?;
+
+        Ok(match (key, value) {
+            (KEY_VERSION, version) => {
+                let (major, minor) = version
+                    .split_once(".")
+                    .ok_or(MetadataError::ValueParsing(KEY_VERSION))?;
+
+                let major = major
+                    .parse()
+                    .map_err(|_| MetadataError::ValueParsing(KEY_VERSION))?;
+                let minor = minor
+                    .parse()
+                    .map_err(|_| MetadataError::ValueParsing(KEY_VERSION))?;
+
+                Metadata::BagitVersion { major, minor }
+            }
+            (KEY_ENCODING, encoding) => {
+                if encoding != "UTF-8" {
+                    return Err(MetadataError::Encoding);
+                }
+
+                Metadata::Encoding
+            }
+            #[cfg(feature = "date")]
+            (KEY_DATE, date) => {
+                let date =
+                    Date::from_str(date).map_err(|_| MetadataError::ValueParsing(KEY_DATE))?;
+
+                Metadata::BaggingDate(date)
+            }
+            (KEY_OXUM, oxum) => {
+                let (octet_count, stream_count) = oxum
+                    .split_once(".")
+                    .ok_or(MetadataError::ValueParsing(KEY_OXUM))?;
+
+                let octet_count = octet_count
+                    .parse()
+                    .map_err(|_| MetadataError::ValueParsing(KEY_OXUM))?;
+                let stream_count = stream_count
+                    .parse()
+                    .map_err(|_| MetadataError::ValueParsing(KEY_OXUM))?;
+
+                Metadata::PayloadOctetStreamSummary {
+                    octet_count,
+                    stream_count,
+                }
+            }
+            (_, _) => Metadata::Custom {
+                key: Cow::Owned(key.to_string()),
+                value: Cow::Owned(value.to_string()),
+            },
+        })
+    }
+}
+
+impl Metadata<'_> {
+    fn validate_format(key: &str, value: &str) -> Result<(), MetadataError> {
+        if key.is_empty() || value.is_empty() {
+            return Err(MetadataError::Format);
+        }
+
+        if key.contains(':') {
+            return Err(MetadataError::KeyForbiddenCharacter);
+        }
+
+        if value.starts_with(char::is_whitespace) || value.ends_with(char::is_whitespace) {
+            return Err(MetadataError::ValueForbiddenCharacter);
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Metadata<'a> {
+    pub fn custom(key: &'a str, value: &'a str) -> Result<Self, MetadataError> {
+        Self::validate_format(key, value)?;
+
+        Ok(Self::Custom {
+            key: Cow::Borrowed(key),
+            value: Cow::Borrowed(value),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Metadata, MetadataError};
+    use jiff::civil::Date;
+    use std::str::FromStr;
+
+    #[test]
+    fn detect_key() {
+        for (input, output) in [
+            (
+                "Custom-Tag: Custom value",
+                Ok(Metadata::Custom {
+                    key: "Custom-Tag".into(),
+                    value: "Custom value".into(),
+                }),
+            ),
+            (
+                "BagIt-Version: 43.69",
+                Ok(Metadata::BagitVersion {
+                    major: 43,
+                    minor: 69,
+                }),
+            ),
+            ("Tag-File-Character-Encoding: UTF-8", Ok(Metadata::Encoding)),
+            #[cfg(feature = "date")]
+            (
+                "Bagging-Date: 2024-07-28 17:48",
+                Ok(Metadata::BaggingDate(Date::new(2024, 7, 28).unwrap())),
+            ),
+            (
+                "Payload-Oxum: 420.69",
+                Ok(Metadata::PayloadOctetStreamSummary {
+                    octet_count: 420,
+                    stream_count: 69,
+                }),
+            ),
+        ] {
+            assert_eq!(
+                Metadata::from_str(input),
+                output,
+                "failing on input value `{input}`"
+            );
+        }
+    }
+
+    #[cfg(feature = "date")]
+    #[test]
+    fn bagging_date() {
+        let date = Date::new(2024, 7, 28).unwrap();
+        let bagging_date = Metadata::BaggingDate(date);
+
+        assert_eq!(bagging_date.key(), "Bagging-Date");
+        assert_eq!(bagging_date.value(), "2024-07-28");
+        assert_eq!(bagging_date.to_string(), "Bagging-Date: 2024-07-28");
+    }
+
+    #[test]
+    fn custom_from_str() {
+        for (input, output) in [
+            ("lolwrongformat", Err(MetadataError::Format)),
+            ("still wrong format", Err(MetadataError::Format)),
+            ("almost there", Err(MetadataError::Format)),
+            (
+                "Bad:Tag:      Bad Value    ",
+                Err(MetadataError::KeyForbiddenCharacter),
+            ),
+            (
+                "Bad:Tag: GoodValue",
+                Err(MetadataError::KeyForbiddenCharacter),
+            ),
+            (
+                "Good-Tag: \tBad   Value\n \t",
+                Err(MetadataError::ValueForbiddenCharacter),
+            ),
+            (
+                "Good-Tag: Good Value",
+                Ok(Metadata::Custom {
+                    key: "Good-Tag".into(),
+                    value: "Good Value".into(),
+                }),
+            ),
+        ] {
+            assert_eq!(
+                Metadata::from_str(input),
+                output,
+                "failing on input value `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn new_custom() {
+        for (key, value, output) in [
+            ("tag", "", Err(MetadataError::Format)),
+            ("", "value", Err(MetadataError::Format)),
+            (
+                "Bad:Tag",
+                "    Bad Value    ",
+                Err(MetadataError::KeyForbiddenCharacter),
+            ),
+            (
+                "Bad:Tag",
+                "GoodValue",
+                Err(MetadataError::KeyForbiddenCharacter),
+            ),
+            (
+                "Good-Tag",
+                "\tBad   Value\n \t",
+                Err(MetadataError::ValueForbiddenCharacter),
+            ),
+            (
+                "Good-Tag",
+                "Good Value",
+                Ok(Metadata::Custom {
+                    key: "Good-Tag".into(),
+                    value: "Good Value".into(),
+                }),
+            ),
+        ] {
+            assert_eq!(
+                Metadata::custom(key, value),
+                output,
+                "failing with key `{key}` and value `{value}`"
+            );
+        }
+    }
+
+    #[test]
+    fn custom() {
+        let custom = Metadata::Custom {
+            key: "Unusual-But-Correct-Tag".into(),
+            value: "Unexpected but good value".into(),
+        };
+
+        assert_eq!(custom.key(), "Unusual-But-Correct-Tag");
+        assert_eq!(custom.value(), "Unexpected but good value");
+        assert_eq!(
+            custom.to_string(),
+            "Unusual-But-Correct-Tag: Unexpected but good value"
+        );
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -12,7 +12,7 @@ pub const KEY_ENCODING: &str = "Tag-File-Character-Encoding";
 pub const KEY_DATE: &str = "Bagging-Date";
 pub const KEY_OXUM: &str = "Payload-Oxum";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Metadata {
     Custom {
         key: String,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -175,6 +175,7 @@ impl<'a> Metadata<'a> {
 #[cfg(test)]
 mod test {
     use super::{Metadata, MetadataError};
+    #[cfg(feature = "date")]
     use jiff::civil::Date;
     use std::str::FromStr;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -9,7 +9,7 @@ const KEY_DATE: &str = "Bagging-Date";
 const KEY_OXUM: &str = "Payload-Oxum";
 
 #[derive(Debug, PartialEq)]
-enum Metadata<'a> {
+pub enum Metadata<'a> {
     Custom {
         key: Cow<'a, str>,
         value: Cow<'a, str>,
@@ -63,7 +63,7 @@ impl Display for Metadata<'_> {
 }
 
 #[derive(thiserror::Error, Debug, PartialEq)]
-enum MetadataError {
+pub enum MetadataError {
     /// Metadata format must be: "<key>: <value>"
     #[error("Invalid format")]
     Format,

--- a/src/metadata/file.rs
+++ b/src/metadata/file.rs
@@ -61,3 +61,9 @@ impl MetadataFile {
         self.0.into_iter()
     }
 }
+
+impl From<Vec<Metadata>> for MetadataFile {
+    fn from(value: Vec<Metadata>) -> Self {
+        Self(value)
+    }
+}

--- a/src/metadata/file.rs
+++ b/src/metadata/file.rs
@@ -1,0 +1,59 @@
+use super::{Metadata, MetadataError};
+use std::path::Path;
+use std::str::FromStr;
+use tokio::fs;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+#[derive(Debug, PartialEq, Default)]
+pub struct MetadataFile(Vec<Metadata>);
+
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub enum MetadataFileError {
+    /// Metadata errors
+    #[error(transparent)]
+    Metadata(#[from] MetadataError),
+    /// Read file error
+    #[error("Failed to read file: `{0}`")]
+    ReadFile(std::io::ErrorKind),
+}
+
+impl MetadataFile {
+    pub async fn read(path: impl AsRef<Path>) -> Result<Self, MetadataFileError> {
+        let file = fs::File::open(path.as_ref())
+            .await
+            .map_err(|e| MetadataFileError::ReadFile(e.kind()))?;
+        let file = BufReader::new(file);
+        let mut lines = file.lines();
+
+        let mut tags = Vec::new();
+
+        while let Some(line) = lines
+            .next_line()
+            .await
+            .map_err(|e| MetadataFileError::ReadFile(e.kind()))?
+        {
+            tags.push(Metadata::from_str(&line)?);
+        }
+
+        Ok(Self(tags))
+    }
+
+    pub async fn write(&self, path: impl AsRef<Path>) -> Result<(), std::io::Error> {
+        let contents = self
+            .0
+            .iter()
+            .map(|tag| tag.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        fs::write(path.as_ref(), contents).await
+    }
+
+    pub fn add(&mut self, tag: Metadata) {
+        self.0.push(tag);
+    }
+
+    pub fn tags(&self) -> impl Iterator<Item = &Metadata> {
+        self.0.iter()
+    }
+}

--- a/src/metadata/file.rs
+++ b/src/metadata/file.rs
@@ -56,4 +56,8 @@ impl MetadataFile {
     pub fn tags(&self) -> impl Iterator<Item = &Metadata> {
         self.0.iter()
     }
+
+    pub fn consume_tags(self) -> impl IntoIterator<Item = Metadata> {
+        self.0.into_iter()
+    }
 }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -151,4 +151,8 @@ impl<'a> Payload<'a> {
     pub fn absolute_path(&self, bag: &BagIt) -> PathBuf {
         bag.path().join(&self.relative_path)
     }
+
+    pub fn bytes(&self) -> u64 {
+        self.bytes
+    }
 }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -152,6 +152,7 @@ impl<'a> Payload<'a> {
         bag.path().join(&self.relative_path)
     }
 
+    /// Size of payload in bytes
     pub fn bytes(&self) -> u64 {
         self.bytes
     }

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -26,6 +26,9 @@ pub enum PayloadError {
     /// Checksum is not the same after computing it and comparing with the one provided in the bag
     #[error("Provided checksum differs from file on disk")]
     ChecksumDiffers,
+    /// Used for metadata tag `Oxum`
+    #[error("Failed to get file size: {0}")]
+    FileSize(std::io::ErrorKind),
 }
 
 #[derive(Debug, PartialEq)]
@@ -35,6 +38,9 @@ pub struct Payload<'a> {
 
     /// Path relative to the bag directory
     relative_path: std::path::PathBuf,
+
+    /// File size in bytes
+    bytes: u64,
 }
 
 impl Display for Payload<'_> {
@@ -44,11 +50,40 @@ impl Display for Payload<'_> {
 }
 
 impl<'a> Payload<'a> {
-    pub(crate) fn new(relative_path_file: impl AsRef<Path>, checksum: Checksum<'a>) -> Self {
+    #[cfg(test)]
+    pub(crate) fn test_payload(
+        relative_path_file: impl AsRef<Path>,
+        checksum: &'a str,
+        bytes: u64,
+    ) -> Self {
         Self {
-            checksum,
-            relative_path: relative_path_file.as_ref().to_path_buf(),
+            checksum: Checksum::from(checksum),
+            relative_path: PathBuf::from(relative_path_file.as_ref()),
+            bytes,
         }
+    }
+
+    pub(crate) fn new(
+        absolute_base_path: impl AsRef<Path>,
+        relative_path_file: impl AsRef<Path>,
+        checksum: Checksum<'a>,
+    ) -> Result<Self, PayloadError> {
+        let relative_path = relative_path_file.as_ref().to_path_buf();
+
+        // Get absolute path
+        let bytes = absolute_base_path
+            .as_ref()
+            .join(relative_path_file.as_ref())
+            // Get file metadata
+            .metadata()
+            .map(|metadata| metadata.len())
+            .map_err(|e| PayloadError::FileSize(e.kind()))?;
+
+        Ok(Self {
+            checksum,
+            relative_path,
+            bytes,
+        })
     }
 
     pub(crate) async fn from_manifest<'manifest, 'item, ChecksumAlgo: Digest>(
@@ -85,9 +120,16 @@ impl<'a> Payload<'a> {
             return Err(PayloadError::ChecksumDiffers);
         }
 
+        // File size
+        let bytes = file_path
+            .metadata()
+            .map(|metadata| metadata.len())
+            .map_err(|e| PayloadError::FileSize(e.kind()))?;
+
         Ok(Self {
             checksum,
             relative_path: PathBuf::from(relative_file_path),
+            bytes,
         })
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -141,10 +141,9 @@ impl<'a, 'algo> BagIt<'a, 'algo> {
 #[cfg(test)]
 mod test {
 
-    use crate::{error::ReadError, Algorithm, BagIt, Checksum, ChecksumAlgorithm, Payload};
+    use crate::{error::ReadError, Algorithm, BagIt, ChecksumAlgorithm, Payload};
     use md5::Md5;
     use sha2::Sha256;
-    use std::path::Path;
 
     #[tokio::test]
     async fn basic_bag_sha256() {
@@ -158,35 +157,30 @@ mod test {
         let expected = BagIt::from_existing_items(
             bagit_directory,
             vec![
-                Payload::new(
-                    Path::new("data/bagit.md"),
-                    Checksum::from(
-                        "eccdbbade12ba878af8f2140cb00c914f427405a987de2670e5c3014faf59f8e",
-                    ),
+                Payload::test_payload(
+                    "data/bagit.md",
+                    "eccdbbade12ba878af8f2140cb00c914f427405a987de2670e5c3014faf59f8e",
+                    6302,
                 ),
-                Payload::new(
-                    Path::new("data/paper_bag.jpg"),
-                    Checksum::from(
-                        "2b22a8fd0dc46cbdc7a67b6cf588a03a8dd6f8ea23ce0b02e921ca5d79930bb2",
-                    ),
+                Payload::test_payload(
+                    "data/paper_bag.jpg",
+                    "2b22a8fd0dc46cbdc7a67b6cf588a03a8dd6f8ea23ce0b02e921ca5d79930bb2",
+                    19895,
                 ),
-                Payload::new(
-                    Path::new("data/rfc8493.txt"),
-                    Checksum::from(
-                        "4964147d2e6e16442d4a6dbfbe68178a8f33c3e791c06d68a8b33f51ad821537",
-                    ),
+                Payload::test_payload(
+                    "data/rfc8493.txt",
+                    "4964147d2e6e16442d4a6dbfbe68178a8f33c3e791c06d68a8b33f51ad821537",
+                    48783,
                 ),
-                Payload::new(
-                    Path::new("data/sources.csv"),
-                    Checksum::from(
-                        "0fe3bd6e7c36aa2c979f3330037b220c5ca88ed0eabf16622202dc0b33c44e72",
-                    ),
+                Payload::test_payload(
+                    "data/sources.csv",
+                    "0fe3bd6e7c36aa2c979f3330037b220c5ca88ed0eabf16622202dc0b33c44e72",
+                    369,
                 ),
-                Payload::new(
-                    Path::new("data/totebag.jpg"),
-                    Checksum::from(
-                        "38ff57167d746859f6383e80eb84ec0dd84de2ab1ed126ad317e73fbf502fb31",
-                    ),
+                Payload::test_payload(
+                    "data/totebag.jpg",
+                    "38ff57167d746859f6383e80eb84ec0dd84de2ab1ed126ad317e73fbf502fb31",
+                    10417,
                 ),
             ],
             algo.algorithm(),

--- a/src/read.rs
+++ b/src/read.rs
@@ -194,6 +194,7 @@ mod test {
     use crate::{
         error::ReadError, metadata::Metadata, Algorithm, BagIt, ChecksumAlgorithm, Payload,
     };
+    #[cfg(feature = "date")]
     use jiff::civil::Date;
     use md5::Md5;
     use sha2::Sha256;
@@ -238,7 +239,13 @@ mod test {
             ],
             algo.algorithm(),
             vec![
+                #[cfg(feature = "date")]
                 Metadata::BaggingDate(Date::new(2024, 7, 11).unwrap()),
+                #[cfg(not(feature = "date"))]
+                Metadata::Custom {
+                    key: "Bagging-Date".into(),
+                    value: "2024-07-11".into(),
+                },
                 Metadata::PayloadOctetStreamSummary {
                     octet_count: 85766,
                     stream_count: 5,

--- a/src/read.rs
+++ b/src/read.rs
@@ -200,7 +200,7 @@ mod test {
     use sha2::Sha256;
 
     #[tokio::test]
-    async fn basic_bag_sha256() {
+    async fn bag_with_date_sha256() {
         let mut bagit_directory = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         bagit_directory.push("tests/sample-bag");
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -35,6 +35,9 @@ pub enum ReadError {
     /// Error related to `bag-info.txt`
     #[error("Bag info `bag-info.txt`: {0}")]
     BagInfo(#[from] MetadataFileError),
+    /// Error related to `bag-info.txt`
+    #[error("Bag info incorrect Oxum: {0}")]
+    BagInfoOxum(&'static str),
     /// Failed to gather list of potential checksum files
     #[error("Listing checksum files")]
     ListChecksumFiles(std::io::ErrorKind),
@@ -149,12 +152,14 @@ impl<'a, 'algo> BagIt<'a, 'algo> {
                 } = tag
                 {
                     if *stream_count != payloads.len() {
-                        // TODO: error
+                        // Expected number of payloads does not match
+                        return Err(ReadError::BagInfoOxum("stream_count"));
                     }
 
                     let payload_bytes_sum = payloads.iter().map(|payload| payload.bytes()).sum();
                     if *octet_count != payload_bytes_sum {
-                        // TODO: error
+                        // Expected total bytes does not match
+                        return Err(ReadError::BagInfoOxum("octet_count"));
                     }
                 }
             }


### PR DESCRIPTION
- read/write tags from/to file `bag-data.txt`
- using `Metadata` struct for reading and writting `bagit.txt` file
- storing metadata tags inside bag struct
- store file size in `Payload` struct

supporting reading and writing commonly used tags:
- BagIt-Version
- Tag-File-Character-Encoding
- Bagging-Date (with `jiff` crate)
- Payload-Oxum

supporting custom tags with key/value stored as strings